### PR TITLE
Enhanced Scroll Area

### DIFF
--- a/gns3/graphics_view.py
+++ b/gns3/graphics_view.py
@@ -83,7 +83,7 @@ class GraphicsView(QtGui.QGraphicsView):
         scene = QtGui.QGraphicsScene(parent=self)
         width = self._settings["scene_width"]
         height = self._settings["scene_height"]
-        scene.setSceneRect(-(width / 2), -(height / 2), width, height)
+        scene.setSceneRect(-(width / 2), -(height / 2), width + 1000, height + 1000)
         self.setScene(scene)
 
         # set the custom flags for this view


### PR DESCRIPTION
### What I did


I wanted to dynamically change the scrollable area to accommodate all nodes because, as of now, if you zoom out, place a new device, and then zoom back in, and the new device exits the field of view, you cannot scroll to it.

 However, I could not find the function where new devices are being added. So, for the time being, I have simply increased the scenes dimensions.